### PR TITLE
Update Gateway Documentation + NAT Port Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you want bindings in other languages, feel free to open a github issue. Alter
 
 # Documentation
 
-We've got pretty extensive documentation located in the [doc](https://rtradeltd.github.io/TxPB/doc) folder.
+We've got pretty extensive documentation located in the [doc](https://rtradeltd.github.io/TxPB/doc) folder, although the github pages version [here](https://rtradeltd.github.io/TxPB/) is much nicer to look at.
 
 # License
 

--- a/doc/BENCHMARKS.md
+++ b/doc/BENCHMARKS.md
@@ -1,0 +1,5 @@
+# Benchmarks
+
+Benchmarks for TemporalX is a constantly evolving process. With our initial release we did a comparison between processing the same workloads in the same environment on go-ipfs and with TemporalX. To read about that check out our [medium post](https://medium.com/temporal-cloud/temporalx-vs-go-ipfs-official-node-benchmarks-8457037a77cf).
+
+From then on we have been maintaining a set of generalized benchmarks through a public github pages site on the TemporalX repository located [here](https://rtradeltd.github.io/TemporalX/) which uses [gobenchdata](https://github.com/marketplace/actions/continuous-benchmarking-for-go) to capture new benchmarks with each release.

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -148,6 +148,11 @@ node:
       # persistently store DHT information between reboots
       # it does this using a namespaced wrapper around the "storage" datastore specified earlier in the yaml config file
       persistentDHT: "true"
+    # enables modifying libp2p host options
+    host_options:
+      # enable nat port mapping
+      # useful if blocked by a residential connection
+      natPortMap: "true"
   # general node configuration
   opts:
     # enables a bloom+arc cache on top of the blockstore
@@ -449,6 +454,10 @@ Configuration Options:
 ### DHT Options
 
 The `dht_options` section is used to provide optional control of kad dht we instantiate. It currently only supports one setting `persistentDHT` which is used to store DHT records on disk. It enables persisting DHT records long-term, and avoiding storing them in memory which has the side-effect of reducing memory consumption. If set to true, it uses datastore key [namespaces](https://github.com/ipfs/go-datastore/tree/master/namespace) to wrap around the main storage layer of our node. This means that it will use whatever datastore type you define in `node.storage`, and wrap all keys with a `dhtdatastore` prefix.
+
+### Host Options
+
+The `host_options` sectino is used to provide optional control of libp2p host configurations. It currently only supports one setting `natPortMap` which is used to enabled nat port mapping capabilities, and can be useful in situations where punching through NAT is needed.
 
 ## Opts
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -250,7 +250,7 @@ Configuration Options:
 
 The `gateway` section is used to configure the IPFS HTTP Gateway that TemporalX exposes. It has feature parity with `go-ipfs` to a certain extent, ignoring some of the `X-Ipfs-*` headers, while also supporting `/ipld` lookups. When encountering UnixFS directories, a slightly different "directory index" is displayed than what is shown when using `go-ipfs`.
 
-The gateway http server by default enables gzip "level 3" compression, and has a max processing limit of 1000 requests/second, and a 2 minute timeout for inactive connections. Eventually these will be configurable, but for now they are some sensible defualts.
+The gateway http server by default enables gzip "level 3" compression, and has a max processing limit of 1000 requests/second, and a 2 minute timeout for inactive connections. Eventually these will be configurable, but for now they are some sensible defualts. Additionally the gateway will error out when processing a request body 1GB or larger in size.
 
 The gateway offers no write capabilities, and is strictly focused on read-only purposes. Planned features include an in-memory cache. 
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -453,11 +453,11 @@ Configuration Options:
 
 ### DHT Options
 
-The `dht_options` section is used to provide optional control of kad dht we instantiate. It currently only supports one setting `persistentDHT` which is used to store DHT records on disk. It enables persisting DHT records long-term, and avoiding storing them in memory which has the side-effect of reducing memory consumption. If set to true, it uses datastore key [namespaces](https://github.com/ipfs/go-datastore/tree/master/namespace) to wrap around the main storage layer of our node. This means that it will use whatever datastore type you define in `node.storage`, and wrap all keys with a `dhtdatastore` prefix.
+The `dht_options` section is used to provide optional control of kad dht we instantiate. It currently supports one setting `persistentDHT` which is used to store DHT records on disk. It enables persisting DHT records long-term, and avoiding storing them in memory which has the side-effect of reducing memory consumption. If set to true, it uses datastore key [namespaces](https://github.com/ipfs/go-datastore/tree/master/namespace) to wrap around the main storage layer of our node. This means that it will use whatever datastore type you define in `node.storage`, and wrap all keys with a `dhtdatastore` prefix.
 
 ### Host Options
 
-The `host_options` sectino is used to provide optional control of libp2p host configurations. It currently only supports one setting `natPortMap` which is used to enabled nat port mapping capabilities, and can be useful in situations where punching through NAT is needed.
+The `host_options` section is used to provide optional control of libp2p host configurations. It currently supports one setting `natPortMap` which is used to enabled nat port mapping capabilities, and can be useful in situations where punching through NAT is needed.
 
 ## Opts
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -457,7 +457,7 @@ The `dht_options` section is used to provide optional control of kad dht we inst
 
 ### Host Options
 
-The `host_options` section is used to provide optional control of libp2p host configurations. It currently supports one setting `natPortMap` which is used to enabled nat port mapping capabilities, and can be useful in situations where punching through NAT is needed.
+The `host_options` section is used to provide optional control of libp2p host configurations. It currently supports one setting `natPortMap` which is used to enabled nat port mapping capabilities, and can be useful in situations where punching through NAT is needed. For documentation about the exact type of nat port mapping methods used please consult the [go-libp2p-nat docs](https://github.com/libp2p/go-libp2p-nat). 
 
 ## Opts
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -243,7 +243,12 @@ Configuration Options:
 
 ## Gateway
 
-The `gateway` section is ued to configure the IPFS HTTP Gateway that TemporalX exposes. It is the same in functionality to the gateway exposed by `go-ipfs`, with the exception of enabling IPFS, IPNS, and IPLD requests. At the moment we only support resolution of requests using a single CID path. That is, you may only ever request paths like `/ipfs/CID`, `/ipns/CID`, or `/ipld/CID`. It is not currently supported to request paths like `/ipfs/CIDa/CIDb`, etc..
+
+The `gateway` section is used to configure the IPFS HTTP Gateway that TemporalX exposes. It has feature parity with `go-ipfs` to a certain extent, ignoring some of the `X-Ipfs-*` headers, while also supporting `/ipld` lookups. When encountering UnixFS directories, a slightly different "directory index" is displayed than what is shown when using `go-ipfs`.
+
+The gateway http server by default enables gzip "level 3" compression, and has a max processing limit of 1000 requests/second, and a 2 minute timeout for inactive connections. Eventually these will be configurable, but for now they are some sensible defualts.
+
+The gateway offers no write capabilities, and is strictly focused on read-only purposes. Planned features include an in-memory cache. 
 
 Configuration Options:
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -243,7 +243,6 @@ Configuration Options:
 
 ## Gateway
 
-
 The `gateway` section is used to configure the IPFS HTTP Gateway that TemporalX exposes. It has feature parity with `go-ipfs` to a certain extent, ignoring some of the `X-Ipfs-*` headers, while also supporting `/ipld` lookups. When encountering UnixFS directories, a slightly different "directory index" is displayed than what is shown when using `go-ipfs`.
 
 The gateway http server by default enables gzip "level 3" compression, and has a max processing limit of 1000 requests/second, and a 2 minute timeout for inactive connections. Eventually these will be configurable, but for now they are some sensible defualts.

--- a/doc/README.md
+++ b/doc/README.md
@@ -10,3 +10,4 @@ This folder contains all of our documentation including protocol buffer docs, co
 * [License Key Overview](LICENSE_OVERVIEW.md)
 * [Protocol Buffer Documentation](PROTO.md)
 * [TemporalX HTTP Gateway](GATEWAY.md)
+* [Benchmarks](BENCHMARKS.md)


### PR DESCRIPTION
Closes https://github.com/RTradeLtd/TxPB/issues/24, documents nat now being enabled due to https://github.com/libp2p/go-libp2p/pull/748. Also adds a small section on benchmarks