### PR TITLE
Fix Getting Started Systemd Service File

### DIFF
--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -36,15 +36,17 @@ If you use systemd we have a systemd service file that you can use to handle sta
 
 ```
 [Unit]
-Description=Starts the TemporalX service
+Description=temporalx enterprise ipfs client
 After=network.target
 
 [Service]
-User=temporal
-Group=temporal
+User=rtrade
+Group=rtrade
 Type=simple
+LimitNOFILE=65535
 PIDFile=/var/run/temporalx.pid
 ExecStart=/boot_scripts/temporalx_management.sh server
+KillSignal=SIGINT
 
 [Install]
 WantedBy=multi-user.target

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -40,8 +40,8 @@ Description=temporalx enterprise ipfs client
 After=network.target
 
 [Service]
-User=rtrade
-Group=rtrade
+User=temporalx
+Group=temporalx
 Type=simple
 LimitNOFILE=65535
 PIDFile=/var/run/temporalx.pid


### PR DESCRIPTION
The example systemd service file was causing shutdowns for TemporalX to not go through the shutdown process, giving an unclean shutdown. 