### PR TITLE
prevent unpredictable panics from missing logger

### DIFF
--- a/go/rep_client.go
+++ b/go/rep_client.go
@@ -72,6 +72,9 @@ func NewSimpleConnectionProvider(pk libcryto.PrivKey, addPeer AddPeer, logger *z
 	if err != nil {
 		return nil, err
 	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	return &SimpleGRPCConnectionProvider{
 		peerID:    id,
 		tlsConfig: tc,


### PR DESCRIPTION
Although our usage from node is fixed already. This prevents similar errors from occurring for other developers.