### PR TITLE
add reference id for idempotent refence counter operations

### DIFF
--- a/pb/file.proto
+++ b/pb/file.proto
@@ -4,10 +4,12 @@ import "util.proto";
 
 // FileAPI provides a gRPC api to upload/download files as UnixFS objects
 service FileAPI {
-    // UploadFile allows uploading a file as a UnixFS object (equivalent to ipfs add)
+    // UploadFile allows uploading a file as a UnixFS object (equivalent to ipfs pin add)
     rpc UploadFile(stream UploadRequest) returns  (PutResponse) { };
     // DownloadFile allows downloading a UnixFS object (equivalent to ipfs get)
     rpc DownloadFile(DownloadRequest) returns (stream DownloadResponse) { };
+    // RemoveFile allows removing a UnixFS object or decrease it's reference counter (equivalent to ipfs pin rm)
+    rpc RemoveFile(RemoveRequest) returns (RemoveResponse) { };
 }
 
 
@@ -17,6 +19,8 @@ message UploadRequest {
     Blob blob = 1;
     // options allows setting the optoins for this upload
     UploadOptions options = 2;
+    // optional reference ID to mark the file with, only valid in the first message of a stream
+    string refId = 3;
 }
 
 // UploadOptions allows controlling the parameters of a file upload
@@ -64,4 +68,17 @@ message Blob {
     // Currently, DownloadResponse support blob range.
     uint64 rangeStart = 2;
     uint64 rangeEnd = 3;
+}
+
+// UploadRequest is used to decrease the reference count on UnixFS objects
+message RemoveRequest{
+    // refIds is a map of reference IDs to hash/cid of objects to remove those refernece counts
+    map<string, string> refIds = 1;
+}
+
+// RemoveResponse contains the response to a remove request
+message RemoveResponse{
+    // The number of acturall removal operations performed.
+    // A missing count is because the refId to hash pair was already removed or was never added 
+    uint64 count = 1;
 }

--- a/pb/node.proto
+++ b/pb/node.proto
@@ -208,6 +208,11 @@ message BlockstoreRequest {
     // the hash function to use when constructing blocks, default is sha2-256
     // sent by: BS_PUT, BS_PUT_MANY
     string hashFunc = 7;
+    // reference ID to mark the blocks of this operation with
+    // when sent by BS_PUT, BS_PUT_MANY: only put if the id is not marked on block, otherwise noop
+    // when sent by BS_GET, BS_GET_MANY: only get if the id is marked on block
+    // when sent by BS_DELETE: only delete if the id is marked on block
+    string refId = 1;
 }
 
 // BlockstoreResponse is a response to a BlockstoreqRequest
@@ -251,6 +256,8 @@ enum DAGREQTYPE {
     DAG_GET_LINKS = 4;
     // DAG_STAT is used to retrieve ipld.NodeStats information
     DAG_STAT = 5;
+    // DAG_REMOVE is the inverse of DAG_PUT
+    DAG_REMOVE = 6;
 }
 
 // Used to submit a request to Dag or DagStream RPCs
@@ -274,11 +281,14 @@ message DagRequest {
     // sent by: DAG_PUT, DAG_NEW_NODE
     int64 cidVersion = 6;
     // the hash of the object we are processing
-    // sent by: DAG_GET, DAG_NEW_NODe, DAG_ADD_LINKS, DAG_GET_LINKS
+    // sent by: DAG_GET, DAG_NEW_NODe, DAG_ADD_LINKS, DAG_GET_LINKS, DAG_REMOVE
     string hash = 7;
     // indicates links and their names. key = name, value = link hash
     // sent by: DAG_NEW_NODE, DAG_ADD_LINKS
     map<string, string> links = 8;
+    // optional reference ID to mark the cid/hash with
+    // sent by: DAG_PUT, DAG_REMOVE
+    string refId = 2;
 }
 
 // Used in response to a Dag or DagStream RPC
@@ -377,6 +387,8 @@ message KeystoreResponse {
 message PersistRequest {
     // cids to persist locally
     repeated string cids = 1;
+    // optional reference ID to mark the cids with
+    string refId = 2;
 }
 
 message PersistResponse {


### PR DESCRIPTION
The basic design for the protocol, server and client sides to be implemented.

When operating on a reference-counted block store, exact once operation is required to keep the count correct. Although exact once operation is trivial when down locally, it is impossible to guaranty over an unreliable network.

This is worked around by adding a nonce (reference id) to each add operation that can only be removed by calling remove on the same nonce. Not only does this make the operations idempotent (we can safely retry the same operation), it can also prevent users from removing other's users adds.

For example, the s3x client can implement this nonce by `hash(client private key | server public key | bucket name | object name)`. The use of the private key prevents attackers from guessing the hash (and server key prevents cross-server attacks), while bucket and object names allow repeated counts on the same content. Everything is also generated statically so nothing extra needs to be save for deletion.